### PR TITLE
[Superhack-01]Add opcode to geth: experiment with constant return value

### DIFF
--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -477,3 +477,10 @@ func gasSelfdestruct(evm *EVM, contract *Contract, stack *Stack, mem *Memory, me
 	}
 	return gas, nil
 }
+
+// add gas function for inferCall
+func gasInferCall(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
+	//return constant gas
+	var gas uint64 = 20
+	return gas, nil
+}

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -845,6 +845,11 @@ func opSelfdestruct6780(pc *uint64, interpreter *EVMInterpreter, scope *ScopeCon
 	return nil, errStopToken
 }
 
+func opInferCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
+	ret := 5
+	return []byte{byte(ret)}, nil
+}
+
 // following functions are used by the instruction jump  table
 
 // make log instruction function

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -216,6 +216,7 @@ func newByzantiumInstructionSet() JumpTable {
 func newSpuriousDragonInstructionSet() JumpTable {
 	instructionSet := newTangerineWhistleInstructionSet()
 	instructionSet[EXP].dynamicGas = gasExpEIP158
+
 	return validate(instructionSet)
 }
 
@@ -1050,6 +1051,13 @@ func newFrontierInstructionSet() JumpTable {
 			dynamicGas: gasSelfdestruct,
 			minStack:   minStack(1, 0),
 			maxStack:   maxStack(1, 0),
+		},
+		// make infercall min max stack equal to call for now.
+		INFERCALL: {
+			execute:    opInferCall,
+			dynamicGas: gasInferCall,
+			minStack:   minStack(7, 1),
+			maxStack:   maxStack(7, 1),
 		},
 	}
 

--- a/core/vm/opcodes.go
+++ b/core/vm/opcodes.go
@@ -208,6 +208,11 @@ const (
 	LOG4
 )
 
+// 0xb0 range - infercall ops
+const (
+	INFERCALL OpCode = 0xb0
+)
+
 // 0xf0 range - closures.
 const (
 	CREATE       OpCode = 0xf0


### PR DESCRIPTION
Description:
This PR added an opcode `INFERCALL` to geth, including modifying the below file:

1. Add an execution function to `core/vm/instruction.go`
2. Add an opcode to `core/vm/opcodes.go`
3. Add an dynamic gas function which return constant value to `core/vm/gas_table.go`
4. Register new opcode in `core/vm/jump_table.go`

Todo:
Run this updated version of geth and write a smart contract to check if it is working.